### PR TITLE
Fix: remove batch dimension from positional embeddings in ViT notebook.

### DIFF
--- a/paper_walkthrough_vision_transformer_vit.ipynb
+++ b/paper_walkthrough_vision_transformer_vit.ipynb
@@ -1,0 +1,861 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "view-in-github",
+        "colab_type": "text"
+      },
+      "source": [
+        "<a href=\"https://colab.research.google.com/github/bJabbari/medium_articles/blob/fix-pos-embedding/paper_walkthrough_vision_transformer_vit.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "8ecc1865",
+      "metadata": {
+        "id": "8ecc1865"
+      },
+      "outputs": [],
+      "source": [
+        "# Codeblock 1\n",
+        "import torch\n",
+        "import torch.nn as nn\n",
+        "from torchinfo import summary"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "f0861119",
+      "metadata": {
+        "id": "f0861119"
+      },
+      "outputs": [],
+      "source": [
+        "# Codeblock 2\n",
+        "#(1)\n",
+        "BATCH_SIZE   = 1\n",
+        "IMAGE_SIZE   = 224\n",
+        "IN_CHANNELS  = 3\n",
+        "\n",
+        "#(2)\n",
+        "PATCH_SIZE   = 16\n",
+        "NUM_HEADS    = 12\n",
+        "NUM_ENCODERS = 12\n",
+        "EMBED_DIM    = 768\n",
+        "MLP_SIZE     = EMBED_DIM * 4    # 768*4 = 3072\n",
+        "\n",
+        "#(3)\n",
+        "NUM_PATCHES  = (IMAGE_SIZE//PATCH_SIZE) ** 2    # (224//16)**2 = 196\n",
+        "\n",
+        "#(4)\n",
+        "DROPOUT_RATE = 0.1\n",
+        "NUM_CLASSES  = 10"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "8640c4d2",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "8640c4d2",
+        "outputId": "b9e9b51a-bc4e-4f30-b58f-8aa4bd77dec5"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "cuda\n"
+          ]
+        }
+      ],
+      "source": [
+        "# Codeblock 3\n",
+        "device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')\n",
+        "print(device)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "a1302e57",
+      "metadata": {
+        "id": "a1302e57"
+      },
+      "outputs": [],
+      "source": [
+        "# Codeblock 4\n",
+        "class PatcherUnfold(nn.Module):\n",
+        "    def __init__(self):\n",
+        "        super().__init__()\n",
+        "        self.unfold = nn.Unfold(kernel_size=PATCH_SIZE, stride=PATCH_SIZE)    #(1)\n",
+        "        self.linear_projection = nn.Linear(in_features=IN_CHANNELS*PATCH_SIZE*PATCH_SIZE,\n",
+        "                                           out_features=EMBED_DIM)    #(2)\n",
+        "# Codeblock 5\n",
+        "    def forward(self, x):\n",
+        "        print(f'original\\t: {x.size()}')\n",
+        "\n",
+        "        x = self.unfold(x)\n",
+        "        print(f'after unfold\\t: {x.size()}')\n",
+        "\n",
+        "        x = x.permute(0, 2, 1)    #(1)\n",
+        "        print(f'after permute\\t: {x.size()}')\n",
+        "\n",
+        "        x = self.linear_projection(x)\n",
+        "        print(f'after lin proj\\t: {x.size()}')\n",
+        "\n",
+        "        return x"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "eab6bf2b",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "eab6bf2b",
+        "outputId": "773e679c-85ea-43d3-b5da-c14c649d8cb0"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "original\t: torch.Size([1, 3, 224, 224])\n",
+            "after unfold\t: torch.Size([1, 768, 196])\n",
+            "after permute\t: torch.Size([1, 196, 768])\n",
+            "after lin proj\t: torch.Size([1, 196, 768])\n"
+          ]
+        }
+      ],
+      "source": [
+        "# Codeblock 6\n",
+        "patcher_unfold = PatcherUnfold()\n",
+        "x = torch.randn(1, 3, 224, 224)\n",
+        "x = patcher_unfold(x)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "166d9cf4",
+      "metadata": {
+        "id": "166d9cf4"
+      },
+      "outputs": [],
+      "source": [
+        "# Codeblock 7\n",
+        "class PatcherConv(nn.Module):\n",
+        "    def __init__(self):\n",
+        "        super().__init__()\n",
+        "        self.conv = nn.Conv2d(in_channels=IN_CHANNELS,\n",
+        "                              out_channels=EMBED_DIM,\n",
+        "                              kernel_size=PATCH_SIZE,\n",
+        "                              stride=PATCH_SIZE)\n",
+        "\n",
+        "        self.flatten = nn.Flatten(start_dim=2)\n",
+        "\n",
+        "    def forward(self, x):\n",
+        "        print(f'original\\t\\t: {x.size()}')\n",
+        "\n",
+        "        x = self.conv(x)    #(1)\n",
+        "        print(f'after conv\\t\\t: {x.size()}')\n",
+        "\n",
+        "        x = self.flatten(x)    #(2)\n",
+        "        print(f'after flatten\\t\\t: {x.size()}')\n",
+        "\n",
+        "        x = x.permute(0, 2, 1)    #(3)\n",
+        "        print(f'after permute\\t\\t: {x.size()}')\n",
+        "\n",
+        "        return x"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "8b678dfb",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "8b678dfb",
+        "outputId": "f13e8f8c-1b60-4196-d1e9-19518697d302"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "original\t\t: torch.Size([1, 3, 224, 224])\n",
+            "after conv\t\t: torch.Size([1, 768, 14, 14])\n",
+            "after flatten\t\t: torch.Size([1, 768, 196])\n",
+            "after permute\t\t: torch.Size([1, 196, 768])\n"
+          ]
+        }
+      ],
+      "source": [
+        "# Codeblock 8\n",
+        "patcher_conv = PatcherConv()\n",
+        "x = torch.randn(1, 3, 224, 224)\n",
+        "x = patcher_conv(x)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "7f7eec68",
+      "metadata": {
+        "id": "7f7eec68"
+      },
+      "outputs": [],
+      "source": [
+        "# Codeblock 9\n",
+        "class PosEmbedding(nn.Module):\n",
+        "    def __init__(self):\n",
+        "        super().__init__()\n",
+        "        self.class_token = nn.Parameter(torch.randn(size=(1, 1, EMBED_DIM)),\n",
+        "                                        requires_grad=True)    #(1)\n",
+        "        self.pos_embedding = nn.Parameter(torch.randn(size=(1, NUM_PATCHES+1, EMBED_DIM)),\n",
+        "                                          requires_grad=True)    #(2)\n",
+        "        self.dropout = nn.Dropout(p=DROPOUT_RATE)  #(3)\n",
+        "\n",
+        "# Codeblock 10\n",
+        "    def forward(self, x):\n",
+        "        B = x.shape[0]\n",
+        "\n",
+        "        class_token = self.class_token.expand(B, -1, -1)  # [B, 1, EMBED_DIM]\n",
+        "        print(f'class_token dim\\t\\t: {class_token.size()}')\n",
+        "\n",
+        "        print(f'before concat\\t\\t: {x.size()}')\n",
+        "        x = torch.cat([class_token, x], dim=1)    #(1)\n",
+        "        print(f'after concat\\t\\t: {x.size()}')\n",
+        "\n",
+        "        x = self.pos_embedding + x    #(2) [1, N_PATCHES+1, EMBED_DIM] broadcasts to [B, ..., ...]\n",
+        "        print(f'after pos_embedding\\t: {x.size()}')\n",
+        "\n",
+        "        x = self.dropout(x)    #(3)\n",
+        "        print(f'after dropout\\t\\t: {x.size()}')\n",
+        "\n",
+        "        return x"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "1fded900",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "1fded900",
+        "outputId": "4ff465b1-48ba-4593-804c-07c916d6638f"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "class_token dim\t\t: torch.Size([1, 1, 768])\n",
+            "before concat\t\t: torch.Size([1, 196, 768])\n",
+            "after concat\t\t: torch.Size([1, 197, 768])\n",
+            "after pos_embedding\t: torch.Size([1, 197, 768])\n",
+            "after dropout\t\t: torch.Size([1, 197, 768])\n"
+          ]
+        }
+      ],
+      "source": [
+        "# Codeblock 11\n",
+        "pos_embedding = PosEmbedding()\n",
+        "x = pos_embedding(x)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "e015f223",
+      "metadata": {
+        "id": "e015f223"
+      },
+      "outputs": [],
+      "source": [
+        "# Codeblock 12\n",
+        "class TransformerEncoder(nn.Module):\n",
+        "    def __init__(self):\n",
+        "        super().__init__()\n",
+        "\n",
+        "        self.norm_0 = nn.LayerNorm(EMBED_DIM)    #(1)\n",
+        "\n",
+        "        self.multihead_attention = nn.MultiheadAttention(EMBED_DIM,    #(2)\n",
+        "                                                         num_heads=NUM_HEADS,\n",
+        "                                                         batch_first=True,\n",
+        "                                                         dropout=DROPOUT_RATE)\n",
+        "\n",
+        "        self.norm_1 = nn.LayerNorm(EMBED_DIM)    #(3)\n",
+        "\n",
+        "        self.mlp = nn.Sequential(    #(4)\n",
+        "            nn.Linear(in_features=EMBED_DIM, out_features=MLP_SIZE),    #(5)\n",
+        "            nn.GELU(),\n",
+        "            nn.Dropout(p=DROPOUT_RATE),\n",
+        "            nn.Linear(in_features=MLP_SIZE, out_features=EMBED_DIM),    #(6)\n",
+        "            nn.Dropout(p=DROPOUT_RATE)\n",
+        "        )\n",
+        "\n",
+        "# Codeblock 13\n",
+        "    def forward(self, x):\n",
+        "\n",
+        "        residual = x    #(1)\n",
+        "        print(f'residual dim\\t\\t: {residual.size()}')\n",
+        "\n",
+        "        x = self.norm_0(x)    #(2)\n",
+        "        print(f'after norm\\t\\t: {x.size()}')\n",
+        "\n",
+        "        x = self.multihead_attention(x, x, x)[0]    #(3)\n",
+        "        print(f'after attention\\t\\t: {x.size()}')\n",
+        "\n",
+        "        x = x + residual    #(4)\n",
+        "        print(f'after addition\\t\\t: {x.size()}')\n",
+        "\n",
+        "        residual = x    #(5)\n",
+        "        print(f'residual dim\\t\\t: {residual.size()}')\n",
+        "\n",
+        "        x = self.norm_1(x)    #(6)\n",
+        "        print(f'after norm\\t\\t: {x.size()}')\n",
+        "\n",
+        "        x = self.mlp(x)    #(7)\n",
+        "        print(f'after mlp\\t\\t: {x.size()}')\n",
+        "\n",
+        "        x = x + residual    #(8)\n",
+        "        print(f'after addition\\t\\t: {x.size()}')\n",
+        "\n",
+        "        return x"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "9bcba47f",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "9bcba47f",
+        "outputId": "775b4c3e-ebf0-448e-ce72-6e79a2fccff6"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "residual dim\t\t: torch.Size([1, 197, 768])\n",
+            "after norm\t\t: torch.Size([1, 197, 768])\n",
+            "after attention\t\t: torch.Size([1, 197, 768])\n",
+            "after addition\t\t: torch.Size([1, 197, 768])\n",
+            "residual dim\t\t: torch.Size([1, 197, 768])\n",
+            "after norm\t\t: torch.Size([1, 197, 768])\n",
+            "after mlp\t\t: torch.Size([1, 197, 768])\n",
+            "after addition\t\t: torch.Size([1, 197, 768])\n"
+          ]
+        }
+      ],
+      "source": [
+        "# Codeblock 14\n",
+        "transformer_encoder = TransformerEncoder()\n",
+        "x = transformer_encoder(x)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "c970b1b4",
+      "metadata": {
+        "id": "c970b1b4"
+      },
+      "outputs": [],
+      "source": [
+        "# Codeblock 15\n",
+        "class MLPHead(nn.Module):\n",
+        "    def __init__(self):\n",
+        "        super().__init__()\n",
+        "\n",
+        "        self.norm = nn.LayerNorm(EMBED_DIM)\n",
+        "        self.linear_0 = nn.Linear(in_features=EMBED_DIM,\n",
+        "                                  out_features=EMBED_DIM)\n",
+        "        self.gelu = nn.GELU()\n",
+        "        self.linear_1 = nn.Linear(in_features=EMBED_DIM,\n",
+        "                                  out_features=NUM_CLASSES)    #(1)\n",
+        "\n",
+        "    def forward(self, x):\n",
+        "        print(f'original\\t\\t: {x.size()}')\n",
+        "\n",
+        "        x = self.norm(x)\n",
+        "        print(f'after norm\\t\\t: {x.size()}')\n",
+        "\n",
+        "        x = self.linear_0(x)\n",
+        "        print(f'after layer_0 mlp\\t: {x.size()}')\n",
+        "\n",
+        "        x = self.gelu(x)\n",
+        "        print(f'after gelu\\t\\t: {x.size()}')\n",
+        "\n",
+        "        x = self.linear_1(x)\n",
+        "        print(f'after layer_1 mlp\\t: {x.size()}')\n",
+        "\n",
+        "        return x"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "73f5943b",
+      "metadata": {
+        "id": "73f5943b",
+        "outputId": "4726d1a5-9f1a-41a7-bb19-3fb6a9313d78"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "original\t\t: torch.Size([1, 768])\n",
+            "after norm\t\t: torch.Size([1, 768])\n",
+            "after layer_0 mlp\t: torch.Size([1, 768])\n",
+            "after gelu\t\t: torch.Size([1, 768])\n",
+            "after layer_1 mlp\t: torch.Size([1, 10])\n"
+          ]
+        }
+      ],
+      "source": [
+        "# Codeblock 16\n",
+        "x = x[:, 0]    #(1)\n",
+        "mlp_head = MLPHead()\n",
+        "x = mlp_head(x)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "7b88b0ff",
+      "metadata": {
+        "id": "7b88b0ff"
+      },
+      "outputs": [],
+      "source": [
+        "# Codeblock 17\n",
+        "class ViT(nn.Module):\n",
+        "    def __init__(self):\n",
+        "        super().__init__()\n",
+        "\n",
+        "        #self.patcher = PatcherUnfold()\n",
+        "        self.patcher = PatcherConv()    #(1)\n",
+        "        self.pos_embedding = PosEmbedding()\n",
+        "        self.transformer_encoders = nn.Sequential(\n",
+        "            *[TransformerEncoder() for _ in range(NUM_ENCODERS)]    #(2)\n",
+        "            )\n",
+        "        self.mlp_head = MLPHead()\n",
+        "\n",
+        "    def forward(self, x):\n",
+        "\n",
+        "        x = self.patcher(x)\n",
+        "        x = self.pos_embedding(x)\n",
+        "        x = self.transformer_encoders(x)\n",
+        "        x = x[:, 0]    #(3)\n",
+        "        x = self.mlp_head(x)\n",
+        "\n",
+        "        return x"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "c7c298af",
+      "metadata": {
+        "id": "c7c298af",
+        "outputId": "ae022876-3377-4830-df0c-f9fa028f6f75"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "original\t\t: torch.Size([1, 3, 224, 224])\n",
+            "after conv\t\t: torch.Size([1, 768, 14, 14])\n",
+            "after flatten\t\t: torch.Size([1, 768, 196])\n",
+            "after permute\t\t: torch.Size([1, 196, 768])\n",
+            "class_token dim\t\t: torch.Size([1, 1, 768])\n",
+            "before concat\t\t: torch.Size([1, 196, 768])\n",
+            "after concat\t\t: torch.Size([1, 197, 768])\n",
+            "after pos_embedding\t: torch.Size([1, 197, 768])\n",
+            "after dropout\t\t: torch.Size([1, 197, 768])\n",
+            "residual dim\t\t: torch.Size([1, 197, 768])\n",
+            "after norm\t\t: torch.Size([1, 197, 768])\n",
+            "after attention\t\t: torch.Size([1, 197, 768])\n",
+            "after addition\t\t: torch.Size([1, 197, 768])\n",
+            "residual dim\t\t: torch.Size([1, 197, 768])\n",
+            "after norm\t\t: torch.Size([1, 197, 768])\n",
+            "after mlp\t\t: torch.Size([1, 197, 768])\n",
+            "after addition\t\t: torch.Size([1, 197, 768])\n",
+            "residual dim\t\t: torch.Size([1, 197, 768])\n",
+            "after norm\t\t: torch.Size([1, 197, 768])\n",
+            "after attention\t\t: torch.Size([1, 197, 768])\n",
+            "after addition\t\t: torch.Size([1, 197, 768])\n",
+            "residual dim\t\t: torch.Size([1, 197, 768])\n",
+            "after norm\t\t: torch.Size([1, 197, 768])\n",
+            "after mlp\t\t: torch.Size([1, 197, 768])\n",
+            "after addition\t\t: torch.Size([1, 197, 768])\n",
+            "residual dim\t\t: torch.Size([1, 197, 768])\n",
+            "after norm\t\t: torch.Size([1, 197, 768])\n",
+            "after attention\t\t: torch.Size([1, 197, 768])\n",
+            "after addition\t\t: torch.Size([1, 197, 768])\n",
+            "residual dim\t\t: torch.Size([1, 197, 768])\n",
+            "after norm\t\t: torch.Size([1, 197, 768])\n",
+            "after mlp\t\t: torch.Size([1, 197, 768])\n",
+            "after addition\t\t: torch.Size([1, 197, 768])\n",
+            "residual dim\t\t: torch.Size([1, 197, 768])\n",
+            "after norm\t\t: torch.Size([1, 197, 768])\n",
+            "after attention\t\t: torch.Size([1, 197, 768])\n",
+            "after addition\t\t: torch.Size([1, 197, 768])\n",
+            "residual dim\t\t: torch.Size([1, 197, 768])\n",
+            "after norm\t\t: torch.Size([1, 197, 768])\n",
+            "after mlp\t\t: torch.Size([1, 197, 768])\n",
+            "after addition\t\t: torch.Size([1, 197, 768])\n",
+            "residual dim\t\t: torch.Size([1, 197, 768])\n",
+            "after norm\t\t: torch.Size([1, 197, 768])\n",
+            "after attention\t\t: torch.Size([1, 197, 768])\n",
+            "after addition\t\t: torch.Size([1, 197, 768])\n",
+            "residual dim\t\t: torch.Size([1, 197, 768])\n",
+            "after norm\t\t: torch.Size([1, 197, 768])\n",
+            "after mlp\t\t: torch.Size([1, 197, 768])\n",
+            "after addition\t\t: torch.Size([1, 197, 768])\n",
+            "residual dim\t\t: torch.Size([1, 197, 768])\n",
+            "after norm\t\t: torch.Size([1, 197, 768])\n",
+            "after attention\t\t: torch.Size([1, 197, 768])\n",
+            "after addition\t\t: torch.Size([1, 197, 768])\n",
+            "residual dim\t\t: torch.Size([1, 197, 768])\n",
+            "after norm\t\t: torch.Size([1, 197, 768])\n",
+            "after mlp\t\t: torch.Size([1, 197, 768])\n",
+            "after addition\t\t: torch.Size([1, 197, 768])\n",
+            "residual dim\t\t: torch.Size([1, 197, 768])\n",
+            "after norm\t\t: torch.Size([1, 197, 768])\n",
+            "after attention\t\t: torch.Size([1, 197, 768])\n",
+            "after addition\t\t: torch.Size([1, 197, 768])\n",
+            "residual dim\t\t: torch.Size([1, 197, 768])\n",
+            "after norm\t\t: torch.Size([1, 197, 768])\n",
+            "after mlp\t\t: torch.Size([1, 197, 768])\n",
+            "after addition\t\t: torch.Size([1, 197, 768])\n",
+            "residual dim\t\t: torch.Size([1, 197, 768])\n",
+            "after norm\t\t: torch.Size([1, 197, 768])\n",
+            "after attention\t\t: torch.Size([1, 197, 768])\n",
+            "after addition\t\t: torch.Size([1, 197, 768])\n",
+            "residual dim\t\t: torch.Size([1, 197, 768])\n",
+            "after norm\t\t: torch.Size([1, 197, 768])\n",
+            "after mlp\t\t: torch.Size([1, 197, 768])\n",
+            "after addition\t\t: torch.Size([1, 197, 768])\n",
+            "residual dim\t\t: torch.Size([1, 197, 768])\n",
+            "after norm\t\t: torch.Size([1, 197, 768])\n",
+            "after attention\t\t: torch.Size([1, 197, 768])\n",
+            "after addition\t\t: torch.Size([1, 197, 768])\n",
+            "residual dim\t\t: torch.Size([1, 197, 768])\n",
+            "after norm\t\t: torch.Size([1, 197, 768])\n",
+            "after mlp\t\t: torch.Size([1, 197, 768])\n",
+            "after addition\t\t: torch.Size([1, 197, 768])\n",
+            "residual dim\t\t: torch.Size([1, 197, 768])\n",
+            "after norm\t\t: torch.Size([1, 197, 768])\n",
+            "after attention\t\t: torch.Size([1, 197, 768])\n",
+            "after addition\t\t: torch.Size([1, 197, 768])\n",
+            "residual dim\t\t: torch.Size([1, 197, 768])\n",
+            "after norm\t\t: torch.Size([1, 197, 768])\n",
+            "after mlp\t\t: torch.Size([1, 197, 768])\n",
+            "after addition\t\t: torch.Size([1, 197, 768])\n",
+            "residual dim\t\t: torch.Size([1, 197, 768])\n",
+            "after norm\t\t: torch.Size([1, 197, 768])\n",
+            "after attention\t\t: torch.Size([1, 197, 768])\n",
+            "after addition\t\t: torch.Size([1, 197, 768])\n",
+            "residual dim\t\t: torch.Size([1, 197, 768])\n",
+            "after norm\t\t: torch.Size([1, 197, 768])\n",
+            "after mlp\t\t: torch.Size([1, 197, 768])\n",
+            "after addition\t\t: torch.Size([1, 197, 768])\n",
+            "residual dim\t\t: torch.Size([1, 197, 768])\n",
+            "after norm\t\t: torch.Size([1, 197, 768])\n",
+            "after attention\t\t: torch.Size([1, 197, 768])\n",
+            "after addition\t\t: torch.Size([1, 197, 768])\n",
+            "residual dim\t\t: torch.Size([1, 197, 768])\n",
+            "after norm\t\t: torch.Size([1, 197, 768])\n",
+            "after mlp\t\t: torch.Size([1, 197, 768])\n",
+            "after addition\t\t: torch.Size([1, 197, 768])\n",
+            "original\t\t: torch.Size([1, 768])\n",
+            "after norm\t\t: torch.Size([1, 768])\n",
+            "after layer_0 mlp\t: torch.Size([1, 768])\n",
+            "after gelu\t\t: torch.Size([1, 768])\n",
+            "after layer_1 mlp\t: torch.Size([1, 10])\n",
+            "torch.Size([1, 10])\n"
+          ]
+        }
+      ],
+      "source": [
+        "# Codeblock 18\n",
+        "vit = ViT().to(device)\n",
+        "x = torch.randn(1, 3, 224, 224).to(device)\n",
+        "print(vit(x).size())"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "eaee335a",
+      "metadata": {
+        "id": "eaee335a",
+        "outputId": "bb27d3c3-e690-4552-f623-60fc8eac1dff"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "original\t\t: torch.Size([1, 3, 224, 224])\n",
+            "after conv\t\t: torch.Size([1, 768, 14, 14])\n",
+            "after flatten\t\t: torch.Size([1, 768, 196])\n",
+            "after permute\t\t: torch.Size([1, 196, 768])\n",
+            "class_token dim\t\t: torch.Size([1, 1, 768])\n",
+            "before concat\t\t: torch.Size([1, 196, 768])\n",
+            "after concat\t\t: torch.Size([1, 197, 768])\n",
+            "after pos_embedding\t: torch.Size([1, 197, 768])\n",
+            "after dropout\t\t: torch.Size([1, 197, 768])\n",
+            "residual dim\t\t: torch.Size([1, 197, 768])\n",
+            "after norm\t\t: torch.Size([1, 197, 768])\n",
+            "after attention\t\t: torch.Size([1, 197, 768])\n",
+            "after addition\t\t: torch.Size([1, 197, 768])\n",
+            "residual dim\t\t: torch.Size([1, 197, 768])\n",
+            "after norm\t\t: torch.Size([1, 197, 768])\n",
+            "after mlp\t\t: torch.Size([1, 197, 768])\n",
+            "after addition\t\t: torch.Size([1, 197, 768])\n",
+            "residual dim\t\t: torch.Size([1, 197, 768])\n",
+            "after norm\t\t: torch.Size([1, 197, 768])\n",
+            "after attention\t\t: torch.Size([1, 197, 768])\n",
+            "after addition\t\t: torch.Size([1, 197, 768])\n",
+            "residual dim\t\t: torch.Size([1, 197, 768])\n",
+            "after norm\t\t: torch.Size([1, 197, 768])\n",
+            "after mlp\t\t: torch.Size([1, 197, 768])\n",
+            "after addition\t\t: torch.Size([1, 197, 768])\n",
+            "residual dim\t\t: torch.Size([1, 197, 768])\n",
+            "after norm\t\t: torch.Size([1, 197, 768])\n",
+            "after attention\t\t: torch.Size([1, 197, 768])\n",
+            "after addition\t\t: torch.Size([1, 197, 768])\n",
+            "residual dim\t\t: torch.Size([1, 197, 768])\n",
+            "after norm\t\t: torch.Size([1, 197, 768])\n",
+            "after mlp\t\t: torch.Size([1, 197, 768])\n",
+            "after addition\t\t: torch.Size([1, 197, 768])\n",
+            "residual dim\t\t: torch.Size([1, 197, 768])\n",
+            "after norm\t\t: torch.Size([1, 197, 768])\n",
+            "after attention\t\t: torch.Size([1, 197, 768])\n",
+            "after addition\t\t: torch.Size([1, 197, 768])\n",
+            "residual dim\t\t: torch.Size([1, 197, 768])\n",
+            "after norm\t\t: torch.Size([1, 197, 768])\n",
+            "after mlp\t\t: torch.Size([1, 197, 768])\n",
+            "after addition\t\t: torch.Size([1, 197, 768])\n",
+            "residual dim\t\t: torch.Size([1, 197, 768])\n",
+            "after norm\t\t: torch.Size([1, 197, 768])\n",
+            "after attention\t\t: torch.Size([1, 197, 768])\n",
+            "after addition\t\t: torch.Size([1, 197, 768])\n",
+            "residual dim\t\t: torch.Size([1, 197, 768])\n",
+            "after norm\t\t: torch.Size([1, 197, 768])\n",
+            "after mlp\t\t: torch.Size([1, 197, 768])\n",
+            "after addition\t\t: torch.Size([1, 197, 768])\n",
+            "residual dim\t\t: torch.Size([1, 197, 768])\n",
+            "after norm\t\t: torch.Size([1, 197, 768])\n",
+            "after attention\t\t: torch.Size([1, 197, 768])\n",
+            "after addition\t\t: torch.Size([1, 197, 768])\n",
+            "residual dim\t\t: torch.Size([1, 197, 768])\n",
+            "after norm\t\t: torch.Size([1, 197, 768])\n",
+            "after mlp\t\t: torch.Size([1, 197, 768])\n",
+            "after addition\t\t: torch.Size([1, 197, 768])\n",
+            "residual dim\t\t: torch.Size([1, 197, 768])\n",
+            "after norm\t\t: torch.Size([1, 197, 768])\n",
+            "after attention\t\t: torch.Size([1, 197, 768])\n",
+            "after addition\t\t: torch.Size([1, 197, 768])\n",
+            "residual dim\t\t: torch.Size([1, 197, 768])\n",
+            "after norm\t\t: torch.Size([1, 197, 768])\n",
+            "after mlp\t\t: torch.Size([1, 197, 768])\n",
+            "after addition\t\t: torch.Size([1, 197, 768])\n",
+            "residual dim\t\t: torch.Size([1, 197, 768])\n",
+            "after norm\t\t: torch.Size([1, 197, 768])\n",
+            "after attention\t\t: torch.Size([1, 197, 768])\n",
+            "after addition\t\t: torch.Size([1, 197, 768])\n",
+            "residual dim\t\t: torch.Size([1, 197, 768])\n",
+            "after norm\t\t: torch.Size([1, 197, 768])\n",
+            "after mlp\t\t: torch.Size([1, 197, 768])\n",
+            "after addition\t\t: torch.Size([1, 197, 768])\n",
+            "residual dim\t\t: torch.Size([1, 197, 768])\n",
+            "after norm\t\t: torch.Size([1, 197, 768])\n",
+            "after attention\t\t: torch.Size([1, 197, 768])\n",
+            "after addition\t\t: torch.Size([1, 197, 768])\n",
+            "residual dim\t\t: torch.Size([1, 197, 768])\n",
+            "after norm\t\t: torch.Size([1, 197, 768])\n",
+            "after mlp\t\t: torch.Size([1, 197, 768])\n",
+            "after addition\t\t: torch.Size([1, 197, 768])\n",
+            "residual dim\t\t: torch.Size([1, 197, 768])\n",
+            "after norm\t\t: torch.Size([1, 197, 768])\n",
+            "after attention\t\t: torch.Size([1, 197, 768])\n",
+            "after addition\t\t: torch.Size([1, 197, 768])\n",
+            "residual dim\t\t: torch.Size([1, 197, 768])\n",
+            "after norm\t\t: torch.Size([1, 197, 768])\n",
+            "after mlp\t\t: torch.Size([1, 197, 768])\n",
+            "after addition\t\t: torch.Size([1, 197, 768])\n",
+            "residual dim\t\t: torch.Size([1, 197, 768])\n",
+            "after norm\t\t: torch.Size([1, 197, 768])\n",
+            "after attention\t\t: torch.Size([1, 197, 768])\n",
+            "after addition\t\t: torch.Size([1, 197, 768])\n",
+            "residual dim\t\t: torch.Size([1, 197, 768])\n",
+            "after norm\t\t: torch.Size([1, 197, 768])\n",
+            "after mlp\t\t: torch.Size([1, 197, 768])\n",
+            "after addition\t\t: torch.Size([1, 197, 768])\n",
+            "residual dim\t\t: torch.Size([1, 197, 768])\n",
+            "after norm\t\t: torch.Size([1, 197, 768])\n",
+            "after attention\t\t: torch.Size([1, 197, 768])\n",
+            "after addition\t\t: torch.Size([1, 197, 768])\n",
+            "residual dim\t\t: torch.Size([1, 197, 768])\n",
+            "after norm\t\t: torch.Size([1, 197, 768])\n",
+            "after mlp\t\t: torch.Size([1, 197, 768])\n",
+            "after addition\t\t: torch.Size([1, 197, 768])\n",
+            "original\t\t: torch.Size([1, 768])\n",
+            "after norm\t\t: torch.Size([1, 768])\n",
+            "after layer_0 mlp\t: torch.Size([1, 768])\n",
+            "after gelu\t\t: torch.Size([1, 768])\n",
+            "after layer_1 mlp\t: torch.Size([1, 10])\n"
+          ]
+        },
+        {
+          "data": {
+            "text/plain": [
+              "==========================================================================================\n",
+              "Layer (type:depth-idx)                   Output Shape              Param #\n",
+              "==========================================================================================\n",
+              "ViT                                      [1, 10]                   --\n",
+              "├─PatcherConv: 1-1                       [1, 196, 768]             --\n",
+              "│    └─Conv2d: 2-1                       [1, 768, 14, 14]          590,592\n",
+              "│    └─Flatten: 2-2                      [1, 768, 196]             --\n",
+              "├─PosEmbedding: 1-2                      [1, 197, 768]             152,064\n",
+              "│    └─Dropout: 2-3                      [1, 197, 768]             --\n",
+              "├─Sequential: 1-3                        [1, 197, 768]             --\n",
+              "│    └─TransformerEncoder: 2-4           [1, 197, 768]             --\n",
+              "│    │    └─LayerNorm: 3-1               [1, 197, 768]             1,536\n",
+              "│    │    └─MultiheadAttention: 3-2      [1, 197, 768]             2,362,368\n",
+              "│    │    └─LayerNorm: 3-3               [1, 197, 768]             1,536\n",
+              "│    │    └─Sequential: 3-4              [1, 197, 768]             4,722,432\n",
+              "│    └─TransformerEncoder: 2-5           [1, 197, 768]             --\n",
+              "│    │    └─LayerNorm: 3-5               [1, 197, 768]             1,536\n",
+              "│    │    └─MultiheadAttention: 3-6      [1, 197, 768]             2,362,368\n",
+              "│    │    └─LayerNorm: 3-7               [1, 197, 768]             1,536\n",
+              "│    │    └─Sequential: 3-8              [1, 197, 768]             4,722,432\n",
+              "│    └─TransformerEncoder: 2-6           [1, 197, 768]             --\n",
+              "│    │    └─LayerNorm: 3-9               [1, 197, 768]             1,536\n",
+              "│    │    └─MultiheadAttention: 3-10     [1, 197, 768]             2,362,368\n",
+              "│    │    └─LayerNorm: 3-11              [1, 197, 768]             1,536\n",
+              "│    │    └─Sequential: 3-12             [1, 197, 768]             4,722,432\n",
+              "│    └─TransformerEncoder: 2-7           [1, 197, 768]             --\n",
+              "│    │    └─LayerNorm: 3-13              [1, 197, 768]             1,536\n",
+              "│    │    └─MultiheadAttention: 3-14     [1, 197, 768]             2,362,368\n",
+              "│    │    └─LayerNorm: 3-15              [1, 197, 768]             1,536\n",
+              "│    │    └─Sequential: 3-16             [1, 197, 768]             4,722,432\n",
+              "│    └─TransformerEncoder: 2-8           [1, 197, 768]             --\n",
+              "│    │    └─LayerNorm: 3-17              [1, 197, 768]             1,536\n",
+              "│    │    └─MultiheadAttention: 3-18     [1, 197, 768]             2,362,368\n",
+              "│    │    └─LayerNorm: 3-19              [1, 197, 768]             1,536\n",
+              "│    │    └─Sequential: 3-20             [1, 197, 768]             4,722,432\n",
+              "│    └─TransformerEncoder: 2-9           [1, 197, 768]             --\n",
+              "│    │    └─LayerNorm: 3-21              [1, 197, 768]             1,536\n",
+              "│    │    └─MultiheadAttention: 3-22     [1, 197, 768]             2,362,368\n",
+              "│    │    └─LayerNorm: 3-23              [1, 197, 768]             1,536\n",
+              "│    │    └─Sequential: 3-24             [1, 197, 768]             4,722,432\n",
+              "│    └─TransformerEncoder: 2-10          [1, 197, 768]             --\n",
+              "│    │    └─LayerNorm: 3-25              [1, 197, 768]             1,536\n",
+              "│    │    └─MultiheadAttention: 3-26     [1, 197, 768]             2,362,368\n",
+              "│    │    └─LayerNorm: 3-27              [1, 197, 768]             1,536\n",
+              "│    │    └─Sequential: 3-28             [1, 197, 768]             4,722,432\n",
+              "│    └─TransformerEncoder: 2-11          [1, 197, 768]             --\n",
+              "│    │    └─LayerNorm: 3-29              [1, 197, 768]             1,536\n",
+              "│    │    └─MultiheadAttention: 3-30     [1, 197, 768]             2,362,368\n",
+              "│    │    └─LayerNorm: 3-31              [1, 197, 768]             1,536\n",
+              "│    │    └─Sequential: 3-32             [1, 197, 768]             4,722,432\n",
+              "│    └─TransformerEncoder: 2-12          [1, 197, 768]             --\n",
+              "│    │    └─LayerNorm: 3-33              [1, 197, 768]             1,536\n",
+              "│    │    └─MultiheadAttention: 3-34     [1, 197, 768]             2,362,368\n",
+              "│    │    └─LayerNorm: 3-35              [1, 197, 768]             1,536\n",
+              "│    │    └─Sequential: 3-36             [1, 197, 768]             4,722,432\n",
+              "│    └─TransformerEncoder: 2-13          [1, 197, 768]             --\n",
+              "│    │    └─LayerNorm: 3-37              [1, 197, 768]             1,536\n",
+              "│    │    └─MultiheadAttention: 3-38     [1, 197, 768]             2,362,368\n",
+              "│    │    └─LayerNorm: 3-39              [1, 197, 768]             1,536\n",
+              "│    │    └─Sequential: 3-40             [1, 197, 768]             4,722,432\n",
+              "│    └─TransformerEncoder: 2-14          [1, 197, 768]             --\n",
+              "│    │    └─LayerNorm: 3-41              [1, 197, 768]             1,536\n",
+              "│    │    └─MultiheadAttention: 3-42     [1, 197, 768]             2,362,368\n",
+              "│    │    └─LayerNorm: 3-43              [1, 197, 768]             1,536\n",
+              "│    │    └─Sequential: 3-44             [1, 197, 768]             4,722,432\n",
+              "│    └─TransformerEncoder: 2-15          [1, 197, 768]             --\n",
+              "│    │    └─LayerNorm: 3-45              [1, 197, 768]             1,536\n",
+              "│    │    └─MultiheadAttention: 3-46     [1, 197, 768]             2,362,368\n",
+              "│    │    └─LayerNorm: 3-47              [1, 197, 768]             1,536\n",
+              "│    │    └─Sequential: 3-48             [1, 197, 768]             4,722,432\n",
+              "├─MLPHead: 1-4                           [1, 10]                   --\n",
+              "│    └─LayerNorm: 2-16                   [1, 768]                  1,536\n",
+              "│    └─Linear: 2-17                      [1, 768]                  590,592\n",
+              "│    └─GELU: 2-18                        [1, 768]                  --\n",
+              "│    └─Linear: 2-19                      [1, 10]                   7,690\n",
+              "==========================================================================================\n",
+              "Total params: 86,396,938\n",
+              "Trainable params: 86,396,938\n",
+              "Non-trainable params: 0\n",
+              "Total mult-adds (Units.MEGABYTES): 173.06\n",
+              "==========================================================================================\n",
+              "Input size (MB): 0.60\n",
+              "Forward/backward pass size (MB): 102.89\n",
+              "Params size (MB): 231.59\n",
+              "Estimated Total Size (MB): 335.08\n",
+              "=========================================================================================="
+            ]
+          },
+          "execution_count": 16,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "# Codeblock 19\n",
+        "summary(vit, input_size=(1,3,224,224))"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.11.4"
+    },
+    "colab": {
+      "provenance": [],
+      "gpuType": "T4",
+      "include_colab_link": true
+    },
+    "accelerator": "GPU"
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}


### PR DESCRIPTION
This PR fixes an issue in the `PosEmbedding` class where `class_token` and `pos_embedding` were defined with the batch size. This 
- causes unnecessary memory usage and
- Breaks weight sharing (each batch has its own version — not learnable globally)). 
**Fix:**
`class_token` and `pos_embedding` were defined with BATCH_SIZE, making them batch-dependent.
Replaced with batch-independent shape:
```
  self.class_token = nn.Parameter(torch.randn(1, 1, EMBED_DIM))
  self.pos_embedding = nn.Parameter(torch.randn(1, NUM_PATCHES + 1, EMBED_DIM))
```
and in forward:
```
 B = x.shape[0]
 class_token = self.class_token.expand(B, -1, -1)  # [B, 1, EMBED_DIM]
```
This change defines the parameters batch-independently as expected in standard ViT implementations.